### PR TITLE
Using original master branch naming

### DIFF
--- a/.ci/env/hostenv.sh
+++ b/.ci/env/hostenv.sh
@@ -4,7 +4,7 @@ hostname=$( uname -n )
 
 if [ "${hostname}" == "polaris" ]; then
   # WSL Agent
-  source ./wsl.sh
+  . ./wsl.sh
 elif [ "${hostname}" == *"cheyenne"* ]; then
   # Cheyenne HPC SuSE PBS
   echo "not set yet"

--- a/.ci/env/hostenv.sh
+++ b/.ci/env/hostenv.sh
@@ -2,10 +2,10 @@
 
 hostname=$( uname -n )
 
-if [ "${hostname}" == "polaris" ]; then
+if [ "${hostname}" = "polaris" ]; then
   # WSL Agent
-  . ./wsl.sh
-elif [ "${hostname}" == *"cheyenne"* ]; then
+  . .ci/env/wsl.sh
+elif [ "${hostname}" = *"cheyenne"* ]; then
   # Cheyenne HPC SuSE PBS
   echo "not set yet"
 fi

--- a/.ci/env/hostenv.sh
+++ b/.ci/env/hostenv.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+hostname=$( uname -n )
+
+if [ "${hostname}" == "polaris" ]; then
+  # WSL Agent
+  source ./wsl.sh
+elif [ "${hostname}" == *"cheyenne"* ]; then
+  # Cheyenne HPC SuSE PBS
+  echo "not set yet"
+fi

--- a/.ci/env/wsl.sh
+++ b/.ci/env/wsl.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export NETCDF=/opt/ncar/netcdf/
+export MPICH=/opt/ncar/mpich

--- a/.ci/tests/build.sh
+++ b/.ci/tests/build.sh
@@ -6,6 +6,8 @@ makejobs=$3
 
 cd $workingDirectory
 
+source .ci/env/hostenv.sh
+
 echo -ne "$compileOption\n" | ./configure
 
 if [ ! -f configure.wrf ]; then

--- a/.ci/tests/build.sh
+++ b/.ci/tests/build.sh
@@ -8,6 +8,7 @@ cd $workingDirectory
 
 . .ci/env/hostenv.sh
 
+./clean -a
 echo "$compileOption" | ./configure
 
 if [ ! -f configure.wrf ]; then

--- a/.ci/tests/build.sh
+++ b/.ci/tests/build.sh
@@ -2,13 +2,13 @@
 workingDirectory=$1
 shift
 compileOption=$1
-makejobs=$3
+makejobs=$2
 
 cd $workingDirectory
 
 . .ci/env/hostenv.sh
 
-echo -ne "$compileOption\n" | ./configure
+echo "$compileOption" | ./configure
 
 if [ ! -f configure.wrf ]; then
   echo  "Failed to configure"

--- a/.ci/tests/build.sh
+++ b/.ci/tests/build.sh
@@ -6,7 +6,7 @@ makejobs=$3
 
 cd $workingDirectory
 
-source .ci/env/hostenv.sh
+. .ci/env/hostenv.sh
 
 echo -ne "$compileOption\n" | ./configure
 

--- a/.ci/wrf_arw_tests.json
+++ b/.ci/wrf_arw_tests.json
@@ -8,7 +8,7 @@
   {
     "submit_options" :
     {
-      "resources"         : "1:ncpus=12",
+      "resources"         : "1:ncpus=20",
       "timelimit"         : "01:00:00"
     },
     "steps" :
@@ -16,24 +16,24 @@
       "serial" :
        { 
         "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "32", "-j 12" ]
+        "arguments"    : [ "32", "-j 20" ]
       },
       "sm" :
        { 
         "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "33", "-j 12" ],
+        "arguments"    : [ "33", "-j 20" ],
         "dependencies" : { "serial" : "afterany" }
       },
       "dm" :
        { 
         "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "34", "-j 12" ],
+        "arguments"    : [ "34", "-j 20" ],
         "dependencies" : { "sm" : "afterany" }
       },
       "dm+sm" :
        { 
         "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "35", "-j 12" ],
+        "arguments"    : [ "35", "-j 20" ],
         "dependencies" : { "dm" : "afterany" }
       }
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Regression Suite
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
     types:    [ labeled ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         ./hpc-workflows/.ci/runner.py .ci/wrf_arw_tests.json gnu -s LOCAL -d ..
 
     - name : Remove 'test' label
-      if : '!cancelled()' && ${{ github.event.label.name == 'test' }}
+      if : ${{ !cancelled() && github.event.label.name == 'test' }}
       env:
         PR_NUMBER: ${{ github.event.number }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
       pull-requests: write
     steps:
     - uses: actions/checkout@v3
-    - name: Run test 0
+      with: 
+        submodules: true
+
+    - name: Test GNU Compilation
       run: |
         ./hpc-workflows/.ci/runner.py .ci/wrf_arw_tests.json gnu -s LOCAL -d ..
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         ./hpc-workflows/.ci/runner.py .ci/wrf_arw_tests.json gnu -s LOCAL -d ..
 
     - name : Remove 'test' label
-      if : ${{ github.event.label.name == 'test' }}
+      if : '!cancelled()' && ${{ github.event.label.name == 'test' }}
       env:
         PR_NUMBER: ${{ github.event.number }}
       run: |


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: master, ci/cd, testing

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
GitHub changed default naming to main, but WRF was made when master was normal

Solution:
Use original master default branch naming convention

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
A       .ci/env/hostenv.sh
A       .ci/env/wsl.sh
M       .ci/tests/build.sh
M       .ci/wrf_arw_tests.json
M       .github/workflows/ci.yml

TESTS CONDUCTED: 
1. We will see

RELEASE NOTE: 
Use CI trigger branch master
