### PR TITLE
Add chem tests to new testing framework

### DIFF
--- a/.ci/tests/build.sh
+++ b/.ci/tests/build.sh
@@ -56,7 +56,7 @@ shift "$((OPTIND - 1))"
 . .ci/env/hostenv.sh $*
 
 # Now evaluate env vars in case it pulls from hostenv.sh
-if [ ! -z $envVars ]; then
+if [ ! -z "$envVars" ]; then
   setenvStr "$envVars"
 fi
 
@@ -77,6 +77,7 @@ if [ ! -f configure.wrf ]; then
   exit 1
 fi
 
+echo "./compile $buildCommand"
 ./compile $buildCommand
 
 result=$?

--- a/.ci/tests/runNamelists.sh
+++ b/.ci/tests/runNamelists.sh
@@ -97,6 +97,9 @@ rd_12_norm=$( realpath .ci/tests/SCRIPTS/rd_l2_norm.py )
 # Go to core dir
 cd $coreDir || exit $?
 
+# Clean up previous runs
+rm wrfinput_d* wrfbdy_d* wrfout_d* wrfchemi_d* wrf_chem_input_d* rsl* real.print.out* wrf.print.out* wrf_d0*_runstats.out qr_acr_qg_V4.dat fort.98 fort.88 -rf
+
 # Link in data in here
 ln -sf $data/* .
 #
@@ -135,8 +138,8 @@ for namelist in $namelists; do
   fi
 
 
-  # Clean up run
-  rm wrfinput_d* wrfbdy_d* wrfout_d* wrfchemi_d* wrf_chem_input_d* rsl* real.print.out* wrf.print.out* wrf_d0*_runstats.out qr_acr_qg_V4.dat fort.98 fort.88 -rf
+  # Clean up output of any of these runs
+  rm wrfinput_d* wrfbdy_d* wrfout_d* rsl* real.print.out* wrf.print.out* wrf_d0*_runstats.out qr_acr_qg_V4.dat fort.98 fort.88 -rf
 
   # Copy namelist
   echo "Setting $namelistFolder/$namelist as namelist.input"

--- a/.ci/wrf_chem_tests.json
+++ b/.ci/wrf_chem_tests.json
@@ -127,13 +127,13 @@
           "-n", "namelist.input.120",
           "-e", "NAMELIST_DIR=em_chem_kpp"
         ],
-        ".*testcase.*::args_kpp" :
+        ".*build.*::args_kpp" :
         [
           "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/usr/bin/yacc"
-        ],
-        "cheyenne"    : { "arguments" : { ".*testcase.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/glade/u/apps/ch/opt/usr/bin/yacc" ] } },
-        "hsn.de.hpc"  : { "arguments" : { ".*testcase.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/glade/u/apps/ch/opt/usr/bin/yacc" ] } }
-      }
+        ]
+      },
+      "cheyenne"    : { "arguments" : { ".*build.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR='/usr/lib64,YACC=/glade/u/apps/ch/opt/usr/bin/yacc -d'" ] } },
+      "hsn.de.hpc"  : { "arguments" : { ".*build.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR='/usr/lib64,YACC=/glade/u/apps/ch/opt/usr/bin/yacc -d'" ] } }
     },
     "steps" :
     {

--- a/.ci/wrf_chem_tests.json
+++ b/.ci/wrf_chem_tests.json
@@ -1,95 +1,168 @@
 {
   "submit_options" :
   {
-    "queue"     : "economy",
-    "timelimit" : "01:00:00",
+    "timelimit" : "00:20:00",
+    "working_directory" : "..",
+    "arguments" : 
+    {
+      "base_env_numprocs"          : [ "-e", "NUM_PROCS=8" ],
+
+      ".*build.*::args_nesting"    : [ "-n", "1" ],
+      ".*build.*::args_configopt"  : [ "-o", "-d" ],
+      ".*build.*::args_build_tgt"  : [ "-b", "em_real -j $NUM_PROCS" ],
+      ".*build.*::args_env"        : [ "-e", "WRF_CHEM=1" ],
+
+      ".*build-serial::args_config": [ "-c", "32" ],
+      ".*build-omp::args_config"   : [ "-c", "33" ],
+      ".*build-mpi::args_config"   : [ "-c", "34" ],
+
+      ".*testcase.*::global_env"   : [ "-e", "DATA=/path/to/data" ],
+      ".*testcase.*::args_always"  : [ "-c", "test/em_real", "-b", "real.exe", "-d", "$DATA/em_chem" ],
+      ".*testcase-mpi.*::exec_mpi" : [ "-p", "mpirun -np $NUM_PROCS" ],
+      ".*testcase-omp.*::env"      : [ "-e", "OMP_NUM_THREADS=$NUM_PROCS" ],
+
+      ".*testcase-serial.*::dir"   : [ "-f", ".ci/tests/SCRIPTS/Namelists/weekly/$NAMELIST_DIR/", "-s", "serial_results" ],
+      ".*testcase-omp.*::dir"      : [ "-f", ".ci/tests/SCRIPTS/Namelists/weekly/$NAMELIST_DIR/", "-i", "serial_results" ],
+      ".*testcase-mpi.*::dir"      : [ "-f", ".ci/tests/SCRIPTS/Namelists/weekly/$NAMELIST_DIR/",    "-i", "serial_results" ]
+    },
+    "polaris"   :
+    {
+      "submission" : "LOCAL",
+      "arguments"  :
+      {
+        ".*testcase.*::global_env"     :
+        [ 
+          "-e", "DATA=/mnt/s/github/data/wrf/regtest/Data",
+          "-e", "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NETCDF/lib"
+        ]
+      }
+    },
     "cheyenne"  :
     {
       "submission" : "PBS",
-      "resources"  : "1:ncpus=8",
+      "queue"     : "premium",
+      "resources"  : "-l select=1:ncpus=8",
       "arguments"  : 
       {
-        "global_modules" : [ "gnu", "netcdf" ]
+        ".*testcase.*::global_env"     :
+        [ 
+          "-e", "DATA=/glade/work/aislas/github/data/wrf/regtest/Data/",
+          "-e", "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NETCDF/lib"
+        ],
+        "global_modules" : [ "gnu", "netcdf" ],
+        ".*mpi.*::mpi_module" : [ "openmpi/4.0.3" ]
       }
     },
-    "wsl" :
+    "hsn.de.hpc"  :
     {
-      "submission" : "LOCAL"
-    }
-  },
-  "chem_serial" :
-  {
-    "submit_options" : { "cheyenne" : { "arguments" : { "test_modules" : [  ] } } },
-    "steps" :
-    {
-      "build" :
+      "submission" : "PBS",
+      "queue"      : "main",
+      "resources"  : "-l select=1:ncpus=16 -l job_priority=economy",
+      "timelimit" : "00:10:00",
+      "arguments"  : 
       {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "32$'\n'1", "-b", "em_real -j 8", "-e", "WRF_CHEM=1" ]
-      },
-      "testcase" :
-      {
-        "submit_options" : { "cheyenne" : { "resources" : "1:ncpus=1" } },
-        "command"      : ".ci/tests/testcase.sh",
-        "arguments"    : [ "-f", "test/em_chem?", "-n", "path/to/namelist?" ],
-        "dependencies" : { "build" : "afterany" }
+        "base_env_numprocs"          : [ "-e", "NUM_PROCS=16" ],
+        ".*testcase.*::global_env"     :
+        [ 
+          "-e", "DATA=/glade/work/aislas/github/data/wrf/regtest/Data/",
+          "-e", "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NETCDF/lib"
+        ],
+        "global_modules" : [ "gcc", "netcdf" ],
+        ".*mpi.*::mpi_module" : [ "cray-mpich" ]
       }
     }
   },
-  "chem_mpi" :
+  "em_chem" :
   {
-    "submit_options" : { "cheyenne" : { "arguments" : { "test_modules" : [  ] } } },
+    "submit_options" :
+    {
+      "arguments" :
+      {
+        ".*testcase.*::args_namelist" : 
+        [ 
+          "-n", "namelist.input.1,namelist.input.2,namelist.input.5",
+          "-e", "NAMELIST_DIR=em_chem"
+        ]
+      }
+    },
     "steps" :
     {
-      "build" :
+      "build-serial" :
+      {
+        "command"      : ".ci/tests/build.sh"
+      },
+      "testcase-serial" :
+      {
+        "submit_options" : {
+                            "cheyenne" : { "resources" : "-l select=1:ncpus=1" },
+                            "derecho"  : { "resources" : "-l select=1:ncpus=1 -l job_priority=economy" }
+                            },
+        "command"      : ".ci/tests/runNamelists.sh",
+        "dependencies" : { "build-serial" : "afterok" }
+      },
+      "build-mpi" :
       {
         "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "32$'\n'1", "-b", "em_real -j 8", "-e", "WRF_CHEM=1" ]
+        "dependencies" : { "testcase-serial" : "afterok" }
       },
-      "testcase" :
+      "testcase-mpi" :
       {
-        "submit_options" : { "cheyenne" : { "resources" : "1:ncpus=1" } },
-        "command"      : ".ci/tests/testcase.sh",
-        "arguments"    : [ "-f", "test/em_chem?", "-n", "path/to/namelist?" ],
-        "dependencies" : { "build" : "afterany" }
+        "submit_options" : { 
+                            "cheyenne" : { "resources" : "-l select=1:ncpus=8:mpiprocs=8" },
+                            "derecho"  : { "resources" : "-l select=1:ncpus=16:mpiprocs=16 -l job_priority=economy" }
+                            },
+        "command"      : ".ci/tests/runNamelists.sh",
+        "dependencies" : { "build-mpi" : "afterok" }
       }
     }
   },
-  "chem_kpp_serial" :
+  "em_chem_kpp" :
   {
-    "submit_options" : { "cheyenne" : { "arguments" : { "test_modules" : [  ] } } },
-    "steps" :
+    "submit_options" :
     {
-      "build" :
+      "arguments" :
       {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "32$'\n'1", "-b", "em_real -j 8", "-e", "WRF_CHEM=1,WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/usr/bin/yacc" ]
-      },
-      "testcase" :
-      {
-        "submit_options" : { "cheyenne" : { "resources" : "1:ncpus=1" } },
-        "command"      : ".ci/tests/testcase.sh",
-        "arguments"    : [ "-f", "test/em_chem?", "-n", "path/to/namelist?" ],
-        "dependencies" : { "build" : "afterany" }
+        ".*testcase.*::args_namelist" : 
+        [ 
+          "-n", "namelist.input.120",
+          "-e", "NAMELIST_DIR=em_chem_kpp"
+        ],
+        ".*testcase.*::args_kpp" :
+        [
+          "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/usr/bin/yacc"
+        ],
+        "cheyenne"    : { "arguments" : { ".*testcase.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/glade/u/apps/ch/opt/usr/bin/yacc" ] } },
+        "hsn.de.hpc"  : { "arguments" : { ".*testcase.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/glade/u/apps/ch/opt/usr/bin/yacc" ] } }
       }
-    }
-  },
-  "chem_kpp_mpi" :
-  {
-    "submit_options" : { "cheyenne" : { "arguments" : { "test_modules" : [  ] } } },
+    },
     "steps" :
     {
-      "build" :
+      "build-serial" :
+      {
+        "command"      : ".ci/tests/build.sh"
+      },
+      "testcase-serial" :
+      {
+        "submit_options" : {
+                            "cheyenne" : { "resources" : "-l select=1:ncpus=1" },
+                            "derecho"  : { "resources" : "-l select=1:ncpus=1 -l job_priority=economy" }
+                            },
+        "command"      : ".ci/tests/runNamelists.sh",
+        "dependencies" : { "build-serial" : "afterok" }
+      },
+      "build-mpi" :
       {
         "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "32$'\n'1", "-b", "em_real -j 8", "-e", "WRF_CHEM=1,WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/usr/bin/yacc" ]
+        "dependencies" : { "testcase-serial" : "afterok" }
       },
-      "testcase" :
+      "testcase-mpi" :
       {
-        "submit_options" : { "cheyenne" : { "resources" : "1:ncpus=1" } },
-        "command"      : ".ci/tests/testcase.sh",
-        "arguments"    : [ "-f", "test/em_chem?", "-n", "path/to/namelist?" ],
-        "dependencies" : { "build" : "afterany" }
+        "submit_options" : { 
+                            "cheyenne" : { "resources" : "-l select=1:ncpus=4:mpiprocs=4" },
+                            "derecho"  : { "resources" : "-l select=1:ncpus=8:mpiprocs=8 -l job_priority=economy" }
+                            },
+        "command"      : ".ci/tests/runNamelists.sh",
+        "dependencies" : { "build-mpi" : "afterok" }
       }
     }
   }

--- a/.ci/wrf_chem_tests.json
+++ b/.ci/wrf_chem_tests.json
@@ -1,11 +1,11 @@
 {
   "submit_options" :
   {
-    "timelimit" : "00:20:00",
+    "timelimit" : "00:30:00",
     "working_directory" : "..",
     "arguments" : 
     {
-      "base_env_numprocs"          : [ "-e", "NUM_PROCS=8" ],
+      "base_env_numprocs"          : [ "-e", "NUM_PROCS=12" ],
 
       ".*build.*::args_nesting"    : [ "-n", "1" ],
       ".*build.*::args_configopt"  : [ "-o", "-d" ],
@@ -41,7 +41,7 @@
     {
       "submission" : "PBS",
       "queue"     : "premium",
-      "resources"  : "-l select=1:ncpus=8",
+      "resources"  : "-l select=1:ncpus=12",
       "arguments"  : 
       {
         ".*testcase.*::global_env"     :
@@ -108,7 +108,7 @@
       "testcase-mpi" :
       {
         "submit_options" : { 
-                            "cheyenne" : { "resources" : "-l select=1:ncpus=8:mpiprocs=8" },
+                            "cheyenne" : { "resources" : "-l select=1:ncpus=12:mpiprocs=12" },
                             "derecho"  : { "resources" : "-l select=1:ncpus=16:mpiprocs=16 -l job_priority=economy" }
                             },
         "command"      : ".ci/tests/runNamelists.sh",
@@ -132,13 +132,18 @@
           "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64,YACC=/usr/bin/yacc"
         ]
       },
-      "cheyenne"    : { "arguments" : { ".*build.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR='/usr/lib64,YACC=/glade/u/apps/ch/opt/usr/bin/yacc -d'" ] } },
-      "hsn.de.hpc"  : { "arguments" : { ".*build.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR='/usr/lib64,YACC=/glade/u/apps/ch/opt/usr/bin/yacc -d'" ] } }
+      "cheyenne"    : { "arguments" : { ".*build.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64", "-e", "YACC=/glade/u/apps/ch/opt/usr/bin/yacc -d" ] } },
+      "hsn.de.hpc"  : { "arguments" : { ".*build.*::args_kpp" : [ "-e", "WRF_KPP=1,FLEX_LIB_DIR=/usr/lib64", "-e", "YACC=/glade/u/apps/ch/opt/usr/bin/yacc -d" ] } }
     },
     "steps" :
     {
       "build-serial" :
       {
+        "submit_options" :
+        { 
+            "cheyenne" : { "timelimit" : "00:50:00" },
+          "hsn.de.hpc" : { "timelimit" : "00:45:00" }
+        },
         "command"      : ".ci/tests/build.sh"
       },
       "testcase-serial" :
@@ -152,14 +157,19 @@
       },
       "build-mpi" :
       {
+        "submit_options" :
+        { 
+            "cheyenne" : { "timelimit" : "01:20:00" },
+          "hsn.de.hpc" : { "timelimit" : "00:50:00" }
+        },
         "command"      : ".ci/tests/build.sh",
         "dependencies" : { "testcase-serial" : "afterok" }
       },
       "testcase-mpi" :
       {
         "submit_options" : { 
-                            "cheyenne" : { "resources" : "-l select=1:ncpus=4:mpiprocs=4" },
-                            "derecho"  : { "resources" : "-l select=1:ncpus=8:mpiprocs=8 -l job_priority=economy" }
+                            "cheyenne" : { "resources" : "-l select=1:ncpus=12:mpiprocs=12" },
+                            "derecho"  : { "resources" : "-l select=1:ncpus=16:mpiprocs=16 -l job_priority=economy" }
                             },
         "command"      : ".ci/tests/runNamelists.sh",
         "dependencies" : { "build-mpi" : "afterok" }


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: regression, testing, chem, kpp

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Missing chem and chem+kpp tests in new testing framework

Solution:
Add configurations for running the tests on derecho

LIST OF MODIFIED FILES: 
M       .ci/tests/build.sh
M       .ci/tests/runNamelists.sh
M       .ci/wrf_chem_tests.json
M       hpc-workflows

TESTS CONDUCTED: 
1. Tested independently on derecho (requires other non-related bug fixes to WRF)
2. N/A

RELEASE NOTE: 
Add chem tests to new testing framework