### PR TITLE
Increase build times for intel and nvhpc compiler families

### DIFF
--- a/.ci/wrf_compilation_tests-cmake.json
+++ b/.ci/wrf_compilation_tests-cmake.json
@@ -49,53 +49,53 @@
   "cmake-gnu-dm+sm"  : { "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } } },
   
   "cmake-intel-classic-serial" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-intel-classic-sm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-intel-classic-dm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-intel-classic-dm+sm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
 
   "cmake-intel-llvm-serial" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-intel-llvm-sm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-intel-llvm-dm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-intel-llvm-dm+sm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
 
   "cmake-pgi-serial" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-pgi-sm"     : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-pgi-dm"     : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   },
   "cmake-pgi-dm+sm"  : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:25:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/buildCMake.sh" } }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
               - make-pgi-dm+sm
               # add new compilation tests here
 
-        testSet  :
           - host : derecho
             hpc-workflows_path : .ci/hpc-workflows
             archive : /glade/work/aislas/github/runners/wrf/derecho/logs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             args : -j='{"node_select":{"-l ":{"select":1}}}'
             pool  : 8
             tpool : 1
-            mkdirs : true
+            mkdirs : false
             tests :
               - cmake-gnu-serial
               - cmake-gnu-sm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,37 @@ jobs:
               - make-pgi-dm+sm
               # add new compilation tests here
 
+        testSet  :
+          - host : derecho
+            hpc-workflows_path : .ci/hpc-workflows
+            archive : /glade/work/aislas/github/runners/wrf/derecho/logs/
+            account : NMMM0012
+            name : "CMake Compilation Tests"
+            id   : cmake-tests
+            fileroot : wrf_compilation_tests-cmake
+            args : -j='{"node_select":{"-l ":{"select":1}}}'
+            pool  : 8
+            tpool : 1
+            mkdirs : true
+            tests :
+              - cmake-gnu-serial
+              - cmake-gnu-sm
+              - cmake-gnu-dm
+              - cmake-gnu-dm+sm
+              - cmake-intel-classic-serial
+              - cmake-intel-classic-sm
+              - cmake-intel-classic-dm
+              - cmake-intel-classic-dm+sm
+              - cmake-intel-llvm-serial
+              - cmake-intel-llvm-sm
+              - cmake-intel-llvm-dm
+              - cmake-intel-llvm-dm+sm
+              - cmake-pgi-serial
+              - cmake-pgi-sm
+              - cmake-pgi-dm
+              - cmake-pgi-dm+sm
+              # add new compilation tests here
+
     uses : ./.github/workflows/test_workflow.yml
     with :
       # This should be the only hard-coded value, we don't use ${{ inputs.test }}


### PR DESCRIPTION
Insufficient time for certain tests to complete on derecho. Increasing timelimit